### PR TITLE
Catching errors in update function

### DIFF
--- a/boxsizing.htc
+++ b/boxsizing.htc
@@ -84,8 +84,11 @@ function update(){
 		window.clearTimeout(resizetimeout);
 	}
 	resizetimeout = window.setTimeout(function(){
-		restore();
-		init();
+		try{
+			restore();
+			init();
+		}
+		catch(e){}
 		resizetimeout = null;
 	},100);
 }


### PR DESCRIPTION
IE9 in IE7 mode was throwing a javascript error in the restore() function. This happened when an element on the page was being replaced by a new element. The try/catch in restore() was not working properly. I added a try/catch in update() around the call to restore. Please evaluate this fix. Hope this helps.
