### PR TITLE
Stopped it from breaking with block elements of height: 100%

### DIFF
--- a/boxsizing.htc
+++ b/boxsizing.htc
@@ -469,7 +469,7 @@ function updateBorderBoxHeight() {
 	}
 
 	csh = element.currentStyle.minHeight;
-	if(csh != "none"){
+	if(csh != "none" && csh != "100%"){
 		csh = getPixelHeight(element,csh);
 		if(csh !== "none"){
 			if(getBoxSizing() == "border-box"){
@@ -482,7 +482,7 @@ function updateBorderBoxHeight() {
 	}
 
 	csh = element.currentStyle.maxHeight;
-	if(csh != "none"){
+	if(csh != "none" && csh != "100%"){
 		csh = getPixelHeight(element,csh);
 		if(csh !== "none"){
 			if(getBoxSizing() == "border-box"){


### PR DESCRIPTION
If you have, say &lt;body&gt; or a &lt;div&gt; that has height 100%, the polyfill breaks.
The error is pointed out in IE7 on XP as well as in the Edge debugger in IE7 mode.
I believe it is because parseInt(csh) where csh is "100%" doesn't parse properly.
